### PR TITLE
Use the scaling production team html template so that long member names don't get cut off

### DIFF
--- a/public/ff4fe/two-loading-template.html
+++ b/public/ff4fe/two-loading-template.html
@@ -242,7 +242,7 @@
         </tr-player>
 
         <tr-hide-if-empty class="staff abs border-background-1" toggle-class="wtf">
-            <tr-template href="../shared/production-team-noscale.html"></tr-template>
+            <tr-template href="../shared/production-team.html"></tr-template>
         </tr-hide-if-empty>
 
         <!-- <div class="load-best-of">


### PR DESCRIPTION
Fixed per convo in #159 
![scaling1](https://user-images.githubusercontent.com/76075167/125693317-d93fb547-e831-4979-9c3d-1989d454f32a.png)
