### PR TITLE
Fix autofill for coms and hosts

### DIFF
--- a/public/rm/scripts/rm.js
+++ b/public/rm/scripts/rm.js
@@ -23,6 +23,8 @@
         const listings = data.results;
         var select = document.getElementById("schedule_preloads");
 
+        console.log(data.results);
+
         select.appendChild(document.createElement("option"));
 
 
@@ -50,6 +52,8 @@
                 return;
             }
 
+            
+
             var updates = [
                 {
                     property: "game-name",
@@ -70,6 +74,10 @@
 				{
                     property: "commentators",
                     value: listing.commentators[0].name
+                },
+                {
+                    property: "host",
+                    value: listing.hosts[0].name
                 }
             ];
 
@@ -111,6 +119,41 @@
                 }
             }
 
+            let comList = ""
+            let hostList = ""
+         
+            if (listing.commentators != "") {
+                for (coms of listing.commentators) { 
+                    if (comList === "") {
+                        comList += coms.name
+                        if (coms.pronouns != "") {comList += " (" + coms.pronouns + ")"} 
+                    } else {
+                        comList += ", " + coms.name
+                        if (coms.pronouns != "") {comList += " (" + coms.pronouns + ")"} 
+                    }
+                }
+                updates.push({
+                    property: "commentators",
+                    value: comList
+                })
+            }
+            
+            if (listing.hosts != "") {
+                for (host of listing.hosts) { 
+                    if (hostList === "") {
+                        hostList += host.name
+                        if (host.pronouns != "") {hostList += " (" + host.pronouns + ")"} 
+                    } else {
+                        hostList += ", " + host.name
+                        if (host.pronouns != "") {hostList += " (" + host.pronouns + ")"} 
+                    }
+                }
+                updates.push({
+                    property: "hosts",
+                    value: hostList
+                })
+            }
+
             Tracker.updateLayoutMultiple(updates);
         }
 	}
@@ -133,7 +176,7 @@
 			setTimeout(
 				function(){
 					fetchRunData();
-				}, 100
+				}, 1000
 				)
 			});
 

--- a/public/rm/scripts/rm.js
+++ b/public/rm/scripts/rm.js
@@ -50,8 +50,6 @@
                 return;
             }
 
-            
-
             var updates = [
                 {
                     property: "game-name",
@@ -68,14 +66,6 @@
                 {
                     property: "game-category",
                     value: listing.category.substring(2)
-                },
-				{
-                    property: "commentators",
-                    value: listing.commentators[0].name
-                },
-                {
-                    property: "host",
-                    value: listing.hosts[0].name
                 }
             ];
 
@@ -120,7 +110,7 @@
             let comList = ""
             let hostList = ""
          
-            if (listing.commentators != "") {
+            if (listing.commentators.length > 0) {
                 for (coms of listing.commentators) { 
                     if (comList === "") {
                         comList += coms.name
@@ -134,9 +124,14 @@
                     property: "commentators",
                     value: comList
                 })
+            } else {
+                updates.push({
+                    property: "commentators",
+                    value: ""
+                })
             }
             
-            if (listing.hosts != "") {
+            if (listing.hosts.length > 0) {
                 for (host of listing.hosts) { 
                     if (hostList === "") {
                         hostList += host.name
@@ -149,6 +144,11 @@
                 updates.push({
                     property: "hosts",
                     value: hostList
+                })
+            } else {
+                updates.push({
+                    property: "hosts",
+                    value: ""
                 })
             }
 

--- a/public/rm/scripts/rm.js
+++ b/public/rm/scripts/rm.js
@@ -23,8 +23,6 @@
         const listings = data.results;
         var select = document.getElementById("schedule_preloads");
 
-        console.log(data.results);
-
         select.appendChild(document.createElement("option"));
 
 


### PR DESCRIPTION
Ugly method of pulling multiple commentators with pronouns into the commentator field. Has the same ability for hosts, wherever that information needs to go, but not currently displayed on layouts